### PR TITLE
adds vscan for initial and hardened image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,3 +47,12 @@ jobs:
     secrets: inherit
     with:
       image: ${{ needs.build.outputs.image }}
+
+  # The (optional) callable workflow to create the Vulnerability Scan Report 
+  # of the unoptimized image produced by the "build" workflow. 
+  vulnerability-scan:
+    needs: build
+    uses: ./.github/workflows/vscan.yaml
+    secrets: inherit
+    with:
+      image: ${{ needs.build.outputs.image }}

--- a/.github/workflows/harden.yaml
+++ b/.github/workflows/harden.yaml
@@ -52,20 +52,6 @@ jobs:
         with:
           token: ${{ secrets.SLIM_TOKEN }}
       
-      # Creates Vulnerability Scan Report for the Original Image and upload
-      # it as artifacts.          
-      - name: Create Vuln Scan Report for Original Image
-        run: |
-          export IMAGE=${{ inputs.image }}
-          NX_ID=$(slim workflows run --no-cache --image ${IMAGE} --gen-defn-for vscan 2>/dev/null | jq -r '.["vscan-simple"].id')
-          slim workflows get-result-report --id ${NX_ID} 2>/dev/null | jq . > report.txt
-      - name: Upload vuln-scan result for Original image 
-        uses: actions/upload-artifact@v3
-        with:
-          name: original-image-vuln-scan-report
-          path: report.txt
-          retention-days: 7
-    
       # Build the Instrumented image. When the instrument command is done,
       # the instrumented image will be available in the registry.
       #
@@ -135,20 +121,6 @@ jobs:
         run: |
           slim harden --id ${{ needs.instrument.outputs.inst-id }}
 
-      # Creates Vulnerability Scan Report for Hardened Image and upload
-      # it as artifacts.          
-      - name: Create Vuln Scan Report for Hardened Image
-        run: |
-          export HARD_IMAGE=${{ needs.instrument.outputs.hard-image }}
-          NX_ID=$(slim workflows run --no-cache --image ${HARD_IMAGE} --gen-defn-for vscan 2>/dev/null | jq -r '.["vscan-simple"].id')
-          slim workflows get-result-report --id ${NX_ID} 2>/dev/null | jq . > report.txt
-      - name: Upload vuln-scan result for hardened image 
-        uses: actions/upload-artifact@v3
-        with:
-          name: hardened-image-vuln-scan-report
-          path: report.txt
-          retention-days: 7
-
   # The (optional) Verify stage: Run a container using the Hardened Image
   #                              and see if it's actually functional.
   verify:
@@ -173,3 +145,12 @@ jobs:
             [ "$i" = "5" ] && echo "FAIL" && exit 1
             sleep 5
           done
+
+  # The (optional) callable workflow to create the Vulnerability Scan Report 
+  # of the hardened image 
+  vulnerability-scan:
+    needs: harden
+    uses: ./.github/workflows/vscan.yaml
+    secrets: inherit
+    with:
+      image: ${{ needs.instrument.outputs.hard-image }}

--- a/.github/workflows/harden.yaml
+++ b/.github/workflows/harden.yaml
@@ -51,7 +51,21 @@ jobs:
       - uses: ./.github/actions/slimctl
         with:
           token: ${{ secrets.SLIM_TOKEN }}
-
+      
+      # Creates Vulnerability Scan Report for the Original Image and upload
+      # it as artifacts.          
+      - name: Create Vuln Scan Report for Original Image
+        run: |
+          export IMAGE=${{ inputs.image }}
+          NX_ID=$(slim workflows run --no-cache --image ${IMAGE} --gen-defn-for vscan 2>/dev/null | jq -r '.["vscan-simple"].id')
+          slim workflows get-result-report --id ${NX_ID} 2>/dev/null | jq . > report.txt
+      - name: Upload vuln-scan result for Original image 
+        uses: actions/upload-artifact@v3
+        with:
+          name: original-image-vuln-scan-report
+          path: report.txt
+          retention-days: 7
+    
       # Build the Instrumented image. When the instrument command is done,
       # the instrumented image will be available in the registry.
       #
@@ -120,6 +134,20 @@ jobs:
       - name: Harden the Target Image
         run: |
           slim harden --id ${{ needs.instrument.outputs.inst-id }}
+
+      # Creates Vulnerability Scan Report for Hardened Image and upload
+      # it as artifacts.          
+      - name: Create Vuln Scan Report for Hardened Image
+        run: |
+          export HARD_IMAGE=${{ needs.instrument.outputs.hard-image }}
+          NX_ID=$(slim workflows run --no-cache --image ${HARD_IMAGE} --gen-defn-for vscan 2>/dev/null | jq -r '.["vscan-simple"].id')
+          slim workflows get-result-report --id ${NX_ID} 2>/dev/null | jq . > report.txt
+      - name: Upload vuln-scan result for hardened image 
+        uses: actions/upload-artifact@v3
+        with:
+          name: hardened-image-vuln-scan-report
+          path: report.txt
+          retention-days: 7
 
   # The (optional) Verify stage: Run a container using the Hardened Image
   #                              and see if it's actually functional.

--- a/.github/workflows/vscan.yaml
+++ b/.github/workflows/vscan.yaml
@@ -29,12 +29,12 @@ jobs:
 
       # Creates Vulnerability Scan Report for the input Image and upload
       # it as artifacts.          
-      - name: Create Vulnerability Scan Report for input Image
+      - name: Trigger multi-scanner pass for the Image (using the Slim.AI infrastructure)
         run: |
           export IMAGE=${{ inputs.image }}
           NX_ID=$(slim workflows run --no-cache --image ${IMAGE} --gen-defn-for vscan 2>/dev/null | jq -r '.["vscan-simple"].id')
           slim workflows get-result-report --id ${NX_ID} 2>/dev/null | jq . > report.txt
-      - name: Upload vulnerability scan result for the image
+      - name: Save the Vulnerability Scanning results as an artifact for future reference.
         uses: actions/upload-artifact@v3
         with:
           name: ${{ inputs.image }}-vuln-scan-report

--- a/.github/workflows/vscan.yaml
+++ b/.github/workflows/vscan.yaml
@@ -1,0 +1,42 @@
+# A workflow to create the Vulnerability Scan Report of the input image 
+# that may be (unoptimized) version of the image initally built
+# or the hardened image.
+#
+# The current workflow:
+#  - Installs slimctl.
+#  - Creates the Vulnerability Scan Report of the input image
+
+name: vulnerability-scan
+on:
+  workflow_call:
+    inputs:
+      # The image whose Vulnerability scan report will be created.
+      image:
+        required: true
+        type: string
+
+jobs:
+  vulnerability-scan:
+    runs-on: ubuntu-latest
+    steps:
+      # TMP WORKAROUND: Until the slimctl action is published.
+      - uses: actions/checkout@v3
+
+      # Install and configure the slimctl CLI.
+      - uses: ./.github/actions/slimctl
+        with:
+          token: ${{ secrets.SLIM_TOKEN }}
+
+      # Creates Vulnerability Scan Report for the input Image and upload
+      # it as artifacts.          
+      - name: Create Vulnerability Scan Report for input Image
+        run: |
+          export IMAGE=${{ inputs.image }}
+          NX_ID=$(slim workflows run --no-cache --image ${IMAGE} --gen-defn-for vscan 2>/dev/null | jq -r '.["vscan-simple"].id')
+          slim workflows get-result-report --id ${NX_ID} 2>/dev/null | jq . > report.txt
+      - name: Upload vulnerability scan result for the image
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.image }}-vuln-scan-report
+          path: report.txt
+          retention-days: 7


### PR DESCRIPTION
Adds vuln scan report to workflow for both hardened and original image with retention period of 7 days. This is how i tested in separate repo https://github.com/mritunjaysharma394/ich-k8s-example/actions/runs/4230143189